### PR TITLE
Create secret for bind credentials

### DIFF
--- a/library/asb_encode_binding.py
+++ b/library/asb_encode_binding.py
@@ -51,7 +51,7 @@ try:
     config.load_kube_config()
     api = client.CoreV1Api()
 except Exception as error:
-    ansible_module.fail_json(msg="Error attempting to load kubernetes client: " + str(error))
+    ansible_module.fail_json(msg="Error attempting to load kubernetes client: {}".format(error))
 
 ENCODED_BINDING_PATH = "/var/tmp/bind-creds"
 ENV_NAMESPACE = "POD_NAMESPACE"
@@ -70,12 +70,12 @@ def main():
         fields_json = json.dumps(ansible_module.params['fields'])
         encoded_fields = base64.b64encode(fields_json)
     except Exception as error:
-        ansible_module.fail_json(msg="Error attempting to encode binding: " + str(error))
+        ansible_module.fail_json(msg="Error attempting to encode binding: {}".format(error))
 
     try:
         namespace = os.environ[ENV_NAMESPACE]
     except Exception as error:
-        ansible_module.fail_json(msg="Error attempting to get namespace from environment: " + str(error))
+        ansible_module.fail_json(msg="Error attempting to get namespace from environment: {}".format(error))
 
     try:
 	api.create_namespaced_secret(
@@ -86,7 +86,7 @@ def main():
 	    )
 	)
     except Exception as error:
-        ansible_module.fail_json(msg="Error attempting to create binding secret: " + str(error))
+        ansible_module.fail_json(msg="Error attempting to create binding secret: {}".format(error))
 
     ansible_module.exit_json(changed=True, encoded_fields=encoded_fields)
 

--- a/library/asb_encode_binding.py
+++ b/library/asb_encode_binding.py
@@ -54,8 +54,8 @@ except Exception as error:
     ansible_module.fail_json(msg="Error attempting to load kubernetes client: {}".format(error))
 
 ENCODED_BINDING_PATH = "/var/tmp/bind-creds"
+ENV_NAME = "POD_NAME"
 ENV_NAMESPACE = "POD_NAMESPACE"
-SECRET_NAME = "asb-encode-binding"
 
 
 def main():
@@ -73,15 +73,16 @@ def main():
         ansible_module.fail_json(msg="Error attempting to encode binding: {}".format(error))
 
     try:
+        name = os.environ[ENV_NAME]
         namespace = os.environ[ENV_NAMESPACE]
     except Exception as error:
-        ansible_module.fail_json(msg="Error attempting to get namespace from environment: {}".format(error))
+        ansible_module.fail_json(msg="Error attempting to get name/namespace from environment: {}".format(error))
 
     try:
 	api.create_namespaced_secret(
 	    namespace=namespace,
 	    body=client.V1Secret(
-		metadata=client.V1ObjectMeta(name=SECRET_NAME),
+		metadata=client.V1ObjectMeta(name=name),
 		data={"fields": encoded_fields}
 	    )
 	)

--- a/library/asb_save_test_result.py
+++ b/library/asb_save_test_result.py
@@ -66,7 +66,7 @@ def main():
             if ansible_module.params['msg'] is not None:
                 test_result_file.write("%s\n" % ansible_module.params['msg'])
     except Exception as error:
-        ansible_module.fail_json(msg="Error attempting to write test result: " + str(error))
+        ansible_module.fail_json(msg="Error attempting to write test result: {}".format(error))
 
     ansible_module.exit_json(changed=True)
 


### PR DESCRIPTION
When `asb_encode_binding` is used, we want for a secret to be created in
the transient namespace where the APB is being executed.

See [the proposal](https://github.com/openshift/ansible-service-broker/blob/master/docs/proposals/prop-apb-gen-creds.md)
for more information.