### PR TITLE
Bump version for next release

### DIFF
--- a/.tito/releasers.conf
+++ b/.tito/releasers.conf
@@ -13,10 +13,6 @@ remote_location = http://repos.fedorapeople.org/asb/
 copr_options = --timeout 600
 builder.test = 1
 
-[asb-brew-36]
+[asb-brew]
 releaser = tito.release.DistGitReleaser
-branches = rhaos-3.6-asb-rhel-7
-
-[asb-brew-37]
-releaser = tito.release.DistGitReleaser
-branches = rhaos-3.7-asb-rhel-7
+branches = rhaos-3.10-asb-rhel-7

--- a/ansible-asb-modules.spec
+++ b/ansible-asb-modules.spec
@@ -1,5 +1,5 @@
 Name:           ansible-asb-modules
-Version:        0.1.2
+Version:        0.2.0
 Release:        1%{?dist}
 Summary:        Ansible role containing Ansible Service Broker modules
 License:        ASL 2.0


### PR DESCRIPTION
I went ahead and created a new branch `release-0.1` that ends before @maleck13 's `last_operation`. That way, if a bug against the asb modules comes in, we can fix it for 3.9. This PR just bumps the version for the modules we expect to go in 3.10.