### PR TITLE
Bug 1569220 - Add dashboard_url ansible module

### DIFF
--- a/library/asb_dashboard_url.py
+++ b/library/asb_dashboard_url.py
@@ -1,0 +1,86 @@
+#!/usr/bin/python
+
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: asb_dashboard_url
+short_description: Adds a annotation to the pod running the apb with the dashboard URL
+description:
+     - Takes a string containing the dashboard URL. This URL should point to the provisioned application.
+       This URL is then added an an annotation to the pod executing the apb and read by the broker.
+notes: []
+requirements: []
+author:
+    - "Red Hat, Inc."
+options:
+  description:
+    iption:
+      - 'string describing the last operation'
+    required: true
+    default: ""
+'''
+
+EXAMPLES = '''
+- name: update last operation
+  asb_last_operation:
+    description:
+      "10%: creating service route"
+'''
+RETURN = '''
+
+'''
+
+import json
+import base64
+import os
+from ansible.module_utils.basic import AnsibleModule
+try:
+    from kubernetes import client, config
+    config.load_kube_config()
+    api = client.CoreV1Api()
+except Exception as error:
+    ansible_module.fail_json(msg="Error attempting to load kubernetes client: {}".format(error))
+
+DASHBOARD_URL_ANNOTATION = "apb_dashboard_url"
+ENV_NAME = "POD_NAME"
+ENV_NAMESPACE = "POD_NAMESPACE"
+
+
+def main():
+
+    argument_spec = dict(
+        description=dict(required=True, type='str')
+    )
+
+    ansible_module = AnsibleModule(argument_spec=argument_spec)
+
+    dashUrl = ansible_module.params['dashboard_url']
+
+    try:
+        name = os.environ[ENV_NAME]
+        namespace = os.environ[ENV_NAMESPACE]
+    except KeyError as error:
+        ansible_module.fail_json(msg="Error attempting to update pod with dashboard_url annotation. Missing key from environment: {}".format(error))
+
+    try:
+        pod = api.read_namespaced_pod(
+            name=name,
+            namespace=namespace
+        )
+
+        if not pod.metadata.annotations:
+            pod.metadata.annotations = {}
+        pod.metadata.annotations[DASHBOARD_URL_ANNOTATION] = dashUrl
+        api.replace_namespaced_pod(name=name,namespace=namespace,body=pod,pretty='true')
+    except Exception as error:
+        ansible_module.fail_json(msg="Error attempting to update pod with dashboard_url annotation: {}".format(error))
+
+    ansible_module.exit_json(changed=True, dashboard_url=dashUrl)
+
+
+if __name__ == '__main__':
+    main()

--- a/library/asb_dashboard_url.py
+++ b/library/asb_dashboard_url.py
@@ -11,7 +11,7 @@ module: asb_dashboard_url
 short_description: Adds a annotation to the pod running the apb with the dashboard URL
 dashboard_url:
      - Takes a string containing the dashboard URL. This URL should point to the provisioned application.
-       This URL is then added an an annotation to the pod executing the apb and read by the broker.
+       This URL is then added as an annotation to the pod executing the apb and read by the broker.
 notes: []
 requirements: []
 author:
@@ -19,16 +19,25 @@ author:
 options:
   dashboard_url:
     dashboard_url:
-      - 'string describing the last operation'
+      - 'string containing URL to provisioned application'
     required: true
     default: ""
+env:
+        - Set via the downward API on the APB Pod
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
 '''
 
 EXAMPLES = '''
 - name: update last operation
   asb_dashboard_url:
-    dashboard_url:
-      "10%: creating service route"
+    dashboard_url: automationbroker.io
 '''
 RETURN = '''
 

--- a/library/asb_dashboard_url.py
+++ b/library/asb_dashboard_url.py
@@ -9,7 +9,7 @@ DOCUMENTATION = '''
 ---
 module: asb_dashboard_url
 short_description: Adds a annotation to the pod running the apb with the dashboard URL
-description:
+dashboard_url:
      - Takes a string containing the dashboard URL. This URL should point to the provisioned application.
        This URL is then added an an annotation to the pod executing the apb and read by the broker.
 notes: []
@@ -17,8 +17,8 @@ requirements: []
 author:
     - "Red Hat, Inc."
 options:
-  description:
-    iption:
+  dashboard_url:
+    dashboard_url:
       - 'string describing the last operation'
     required: true
     default: ""
@@ -26,8 +26,8 @@ options:
 
 EXAMPLES = '''
 - name: update last operation
-  asb_last_operation:
-    description:
+  asb_dashboard_url:
+    dashboard_url:
       "10%: creating service route"
 '''
 RETURN = '''
@@ -53,7 +53,7 @@ ENV_NAMESPACE = "POD_NAMESPACE"
 def main():
 
     argument_spec = dict(
-        description=dict(required=True, type='str')
+        dashboard_url=dict(required=True, type='str')
     )
 
     ansible_module = AnsibleModule(argument_spec=argument_spec)


### PR DESCRIPTION
This ansible module can be used to annotate the APB pod with the `dashboard_url` to be passed back to the service catalog. This will then be populated on the corresponding serviceinstance.